### PR TITLE
(feat) Do not use aiohttp DNS cache & don't use threads for DNS resolution

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -74,7 +74,7 @@ async def run_outgoing_application():
         feed_endpoints = [parse_feed_config(feed) for feed in env['FEEDS']]
 
     raven_client = get_raven_client(sentry)
-    conn = aiohttp.TCPConnector(use_dns_cache=False)
+    conn = aiohttp.TCPConnector(use_dns_cache=False, resolver=aiohttp.AsyncResolver())
     session = aiohttp.ClientSession(connector=conn, skip_auto_headers=['Accept-Encoding'])
     redis_client = await aioredis.create_redis(redis_uri)
 

--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -74,7 +74,8 @@ async def run_outgoing_application():
         feed_endpoints = [parse_feed_config(feed) for feed in env['FEEDS']]
 
     raven_client = get_raven_client(sentry)
-    session = aiohttp.ClientSession(skip_auto_headers=['Accept-Encoding'])
+    conn = aiohttp.TCPConnector(use_dns_cache=False)
+    session = aiohttp.ClientSession(connector=conn, skip_auto_headers=['Accept-Encoding'])
     redis_client = await aioredis.create_redis(redis_uri)
 
     metrics_registry = CollectorRegistry()

--- a/core/requirements.in
+++ b/core/requirements.in
@@ -1,3 +1,4 @@
+aiodns==1.1.1
 aiohttp==3.3.2
 mohawk==0.3.4
 prometheus_client==0.3.0

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+aiodns==1.1.1
 aiohttp==3.3.2
 aioredis==1.1.0
 async-timeout==3.0.0      # via aiohttp, aioredis
@@ -15,6 +16,7 @@ idna==2.6                 # via idna-ssl, yarl
 mohawk==0.3.4
 multidict==4.3.1          # via aiohttp, yarl
 prometheus_client==0.3.0
+pycares==2.3.0            # via aiodns
 raven-aiohttp==0.7.0
 raven==6.9.0
 six==1.11.0               # via mohawk

--- a/core/requirements_test.txt
+++ b/core/requirements_test.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements_test.txt requirements_test.in
 #
+aiodns==1.1.1
 aiohttp==3.3.2
 aioredis==1.1.0
 astroid==1.6.5            # via pylint
@@ -21,6 +22,7 @@ mccabe==0.6.1             # via pylint
 mohawk==0.3.4
 multidict==4.3.1          # via aiohttp, yarl
 prometheus_client==0.3.0
+pycares==2.3.0            # via aiodns
 pylint==1.9.1
 python-dateutil==2.7.3    # via freezegun
 raven-aiohttp==0.7.0


### PR DESCRIPTION
Sentry sometimes shows similar timeouts to the ones reported at

    https://github.com/elastic/elasticsearch-py-async/issues/11