### PR TITLE
(refactor, tests, fix) Use own Raven transport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,7 @@ repos:
         - --disable=attribute-defined-outside-init
         - --disable=duplicate-code
         - --disable=missing-docstring
+        - --disable=protected-access
+        - --disable=too-few-public-methods
         - --disable=too-many-instance-attributes
         - --disable=too-many-lines

--- a/core/app/app_raven.py
+++ b/core/app/app_raven.py
@@ -1,0 +1,63 @@
+import asyncio
+import functools
+
+import raven
+from raven.exceptions import (
+    APIError,
+    RateLimited,
+)
+
+
+def get_raven_client(sentry, session):
+    return raven.Client(
+        sentry['dsn'],
+        environment=sentry['environment'],
+        transport=functools.partial(QueuedAioHttpTransport, session=session))
+
+
+class QueuedAioHttpTransport:
+    # The official Raven asyncio client has assertions which fail on calling of its
+    # close method, and has lots of code which we don't need
+
+    is_async = True
+    scheme = []
+
+    def __init__(self, session):
+        self.session = session
+        self.queue_or_leak = leaky_queue()
+
+    def async_send(self, url, data, headers, success_cb, failure_cb):
+        async def _send():
+            await send(self.session, url, data, headers, success_cb, failure_cb)
+        asyncio.get_event_loop().create_task(self.queue_or_leak(_send))
+
+
+def leaky_queue():
+    lock = asyncio.Lock()
+
+    async def _queue_or_leak(coroutine):
+        if len(lock._waiters) < 100:
+            async with lock:
+                await coroutine()
+
+    return _queue_or_leak
+
+
+async def send(session, url, data, headers, success_cb, failure_cb):
+    try:
+        async with session.post(url, data=data, headers=headers) as response:
+            message = response.headers.get('x-sentry-error', 'NO_ERROR_MESSAGE')
+            retry_after = int(response.headers.get('retry-after', '0'))
+            status = response.status
+            if response.status == 200:
+                success_cb()
+            else:
+                error = \
+                    RateLimited(message, retry_after) if status == 429 else \
+                    APIError(message, status)
+                failure_cb(error)
+
+    except asyncio.CancelledError:
+        success_cb()
+    except BaseException as exception:
+        failure_cb(exception)

--- a/core/app/app_utils.py
+++ b/core/app/app_utils.py
@@ -1,13 +1,10 @@
 import asyncio
 import collections
-import functools
 import logging
 import signal
 import sys
 
 import aiohttp
-import raven
-from raven_aiohttp import QueuedAioHttpTransport
 
 from shared.logger import (
     logged,
@@ -76,13 +73,6 @@ async def cancel_non_current_tasks():
         task.cancel()
     # Allow CancelledException to be thrown at the location of all awaits
     await asyncio.sleep(0)
-
-
-def get_raven_client(sentry):
-    return raven.Client(
-        sentry['dsn'],
-        environment=sentry['environment'],
-        transport=functools.partial(QueuedAioHttpTransport, workers=1, qsize=1000))
 
 
 async def sleep(context, interval):

--- a/core/app/tests.py
+++ b/core/app/tests.py
@@ -33,6 +33,7 @@ from .tests_utils import (
     run_app_until_accepts_http,
     run_es_application,
     run_feed_application,
+    run_sentry_application,
     wait_until_get_working,
 )
 
@@ -68,6 +69,9 @@ class TestBase(unittest.TestCase):
                                                  mock_headers,
                                                  feed_requested_callback, 8081)
         self.add_async_cleanup(feed_runner.cleanup)
+
+        sentry_runner = await run_sentry_application()
+        self.add_async_cleanup(sentry_runner.cleanup)
 
         cleanup = await run_app_until_accepts_http()
         self.add_async_cleanup(cleanup)

--- a/core/requirements.in
+++ b/core/requirements.in
@@ -3,6 +3,5 @@ aiohttp==3.3.2
 aioredis==1.1.0
 mohawk==0.3.4
 prometheus_client==0.3.0
-raven-aiohttp==0.7.0
 raven==6.9.0
 ujson==1.35

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -17,7 +17,6 @@ mohawk==0.3.4
 multidict==4.3.1          # via aiohttp, yarl
 prometheus_client==0.3.0
 pycares==2.3.0            # via aiodns
-raven-aiohttp==0.7.0
 raven==6.9.0
 six==1.11.0               # via mohawk
 ujson==1.35

--- a/core/requirements_test.txt
+++ b/core/requirements_test.txt
@@ -25,7 +25,6 @@ prometheus_client==0.3.0
 pycares==2.3.0            # via aiodns
 pylint==1.9.1
 python-dateutil==2.7.3    # via freezegun
-raven-aiohttp==0.7.0
 raven==6.9.0
 six==1.11.0               # via astroid, freezegun, mohawk, pylint, python-dateutil
 ujson==1.35


### PR DESCRIPTION


    This...

    - Fixes our own flaky tests due to breaking assertions inside the official
      client. Suspect there were some race conditions on calling its close method
      just after (or before?) exceptions are passed to it. Simpler to just close the
      surrounding session.

    - Allows us to use our own aiohttp session. The default one created, "secretly"
      uses threads when doing DNS resolution, which in addition to mixing models of
      concurrency, and so harder to reason about (say, if we have some future
      problem), uses more memory (8mb per thread?), has its own internal 10-second
      DNS cache (and so seems to ignore DNS TTL?) and runs the risk of blocking the
      event loop due to the GIL.