### PR TITLE
(feat) Add a sleep between full ingest pages

### DIFF
--- a/core/app/app_feeds.py
+++ b/core/app/app_feeds.py
@@ -20,7 +20,7 @@ def parse_feed_config(feed_config):
 
 class ActivityStreamFeed:
 
-    full_ingest_page_interval = 0
+    full_ingest_page_interval = 0.25
     updates_page_interval = 1
     exception_intervals = [1, 2, 4, 8, 16, 32, 64]
 


### PR DESCRIPTION
The full ingest doesn't seem to cause a problem as such, but no need for it to
be hitting it so hard. Expopps production was done in ~2.5 mins. Can be much
slower.