### PR TITLE
(feat) No need for 10 second extra to status expiry

### DIFF
--- a/core/app/app_incoming_redis.py
+++ b/core/app/app_incoming_redis.py
@@ -4,7 +4,6 @@ from . import settings
 # ever if the feed is turned off
 FEED_UPDATE_URL_EXPIRE = 60 * 60 * 24 * 31
 NOT_EXISTS = b'__NOT_EXISTS__'
-SHOW_FEED_AS_RED_IF_NO_REQUEST_IN_SECONDS = 10
 
 
 async def set_private_scroll_id(context, public_scroll_id, private_scroll_id):
@@ -28,7 +27,7 @@ async def set_nonce_nx(context, nonce_key, nonce_expire):
 async def set_feed_status(context, feed_id, feed_max_interval, status):
     await context.redis_client.execute(
         'SET', feed_id + '-status', status,
-        'EX', feed_max_interval + SHOW_FEED_AS_RED_IF_NO_REQUEST_IN_SECONDS)
+        'EX', feed_max_interval)
 
 
 async def get_feeds_status(context, feed_ids):


### PR DESCRIPTION
Each feed to configured separately to have the max time expected between
requests before reporting as down