### PR TITLE
(feat) Use same number of shards per index as ES nodes in PaaS

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -164,7 +164,7 @@ async def create_activities_index(context, index_name):
         index_definition = ujson.dumps({
             'settings': {
                 'index': {
-                    'number_of_shards': 4,
+                    'number_of_shards': 3,
                     'number_of_replicas': 1,
                     'refresh_interval': '-1',
                 }
@@ -200,7 +200,7 @@ async def create_objects_index(context, index_name):
         index_definition = ujson.dumps({
             'settings': {
                 'index': {
-                    'number_of_shards': 4,
+                    'number_of_shards': 3,
                     'number_of_replicas': 1,
                     'refresh_interval': '-1',
                 }

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -460,6 +460,9 @@ class TestApplication(TestBase):
 
         query = json.dumps({
             'size': '1',
+            'sort': [
+                {'published': {'order': 'desc'}},
+            ]
         }).encode('utf-8')
         auth = hawk_auth_header(
             'incoming-some-id-3', 'incoming-some-secret-3', url_1,

--- a/core/tests/tests_utils.py
+++ b/core/tests/tests_utils.py
@@ -166,7 +166,7 @@ async def get(url, auth, x_forwarded_for, body):
 
 
 async def get_until(url, x_forwarded_for, condition):
-    body = b'{"size": 1000, "sort": ["_doc"]}'
+    body = b'{"size": 1000, "sort": [{"published": {"order": "desc"}}]}'
     while True:
         auth = hawk_auth_header(
             'incoming-some-id-3', 'incoming-some-secret-3', url, 'GET', body, 'application/json',


### PR DESCRIPTION
All sizes of ES have 3 nodes in PaaS, so this is likely to give a more
even split of data/load [although the number of CPUs per node is variable].

The the total number of shards will be about:

  (#replicas + 1) * #shards * #feeds * 2 * 2

- The first *2 is since we have both objects and activities indexes.

- The second *2 is since each full ingest ingests into new indexes while
  the old ones still exist

- It's "about" since there will be a period of time between full ingests
  when there are only the fully-filled "live" indexes

- It's also "about" because occasionally deletion of indexes can fail
  when they're being snapshotted.

There may be an argument that is this still too high, but not wanting to
change too much at once.