### PR TITLE
(feat) startTime and endTime mappings

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -196,6 +196,12 @@ async def create_activities_index(context, index_name):
                         'type': {
                             'type': 'keyword',
                         },
+                        'startTime': {
+                            'type': 'date',
+                        },
+                        'endTime': {
+                            'type': 'date',
+                        },
                         'object.type': {
                             'type': 'keyword',
                         },
@@ -207,6 +213,12 @@ async def create_activities_index(context, index_name):
                         },
                         'object.name': {
                             'type': 'text',
+                        },
+                        'object.startTime': {
+                            'type': 'date',
+                        },
+                        'object.endTime': {
+                            'type': 'date',
                         },
                         # Not AS 2.0, but is used, and is a space-separated
                         # list of keywords
@@ -258,6 +270,12 @@ async def create_objects_index(context, index_name):
                         },
                         'name': {
                             'type': 'text',
+                        },
+                        'startTime': {
+                            'type': 'date',
+                        },
+                        'endTime': {
+                            'type': 'date',
                         },
                         # Not AS 2.0, but is used, and is a space-separated
                         # list of keywords


### PR DESCRIPTION
This is to support the upcoming feature of having all opportunities in
the AS, not just the currently active ones. This means that the great
search will have to include endTime in their queries.

Adding startTime for completeness rather than current need.