### PR TITLE
Add attributedTo.id ES mapping

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -225,6 +225,9 @@ async def create_activities_index(context, index_name):
                         'object.keywords': {
                             'type': 'text',
                         },
+                        'object.attributedTo.id': {
+                            'type': 'keyword',
+                        },
                         'actor.dit:companiesHouseNumber': {
                             'type': 'keyword',
                         },
@@ -281,7 +284,10 @@ async def create_objects_index(context, index_name):
                         # list of keywords
                         'keywords': {
                             'type': 'text',
-                        }
+                        },
+                        'attributedTo.id': {
+                            'type': 'keyword',
+                        },
                     },
                 },
             },


### PR DESCRIPTION
This adds `object.attributedTo.id (keyword)` to the ES _activities_ index mapping and `attributedTo.id (keyword)` to the ES `objects` index mapping so that they can be used in queries.