### PR TITLE
(feat) Reduce HTTP timeout so feed will fail and restart

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -128,6 +128,9 @@ async def run_outgoing_application():
     session = aiohttp.ClientSession(
         connector=conn,
         headers={'Accept-Encoding': 'identity;q=1.0, *;q=0'},
+        timeout=aiohttp.ClientTimeout(
+            total=25.0,
+        ),
     )
     redis_client = await redis_get_client(redis_uri)
     raven_client = get_raven_client(sentry, session, metrics)


### PR DESCRIPTION
ActivityStream feeds report as failed after 60 seconds without a
success, so this gives about enough time for 2 failures.