### PR TITLE
(refactor) Wrapping queries in bool query. Towards granular permissions

### DIFF
--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -30,6 +30,7 @@ from .tests_utils import (
     fetch_es_index_names_with_alias,
     get,
     get_until,
+    get_until_with_body,
     has_at_least,
     has_at_least_ordered_items,
     hawk_auth_header,
@@ -522,6 +523,218 @@ class TestApplication(TestBase):
         ids = [item['_source']['id'] for item in result['hits']['hits']]
         self.assertIn('dit:exportOpportunities:Enquiry:42863:Create', ids)
         self.assertIn('dit:exportOpportunities:Enquiry:42862:Create', ids)
+
+    @async_test
+    async def test_v2_activities_get_term_query(self):
+        url = 'http://127.0.0.1:8080/v2/objects'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        desired_id = 'dit:exportOpportunities:Enquiry:49863'
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(1), json.dumps({
+                'query': {'term': {'id': desired_id}}
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        ids = [item['_source']['id'] for item in result['hits']['hits']]
+        self.assertEqual([desired_id], ids)
+
+    @async_test
+    async def test_v2_activities_get_bool_query(self):
+        url = 'http://127.0.0.1:8080/v2/objects'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        desired_id = 'dit:exportOpportunities:Enquiry:49863'
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(1), json.dumps({
+                'query': {'bool': {'must': {'term': {'id': desired_id}}}}
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        ids = [item['_source']['id'] for item in result['hits']['hits']]
+        self.assertEqual([desired_id], ids)
+
+    @async_test
+    async def test_v2_activities_get_function_score_query(self):
+        url = 'http://127.0.0.1:8080/v2/objects'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        desired_id = 'dit:exportOpportunities:Enquiry:49863'
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(1), json.dumps({
+                'query': {
+                    'function_score': {
+                        'query':  {'term': {'id': desired_id}},
+                    }
+                }
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        ids = [item['_source']['id'] for item in result['hits']['hits']]
+        self.assertEqual([desired_id], ids)
+
+    @async_test
+    async def test_v2_activities_get_filter_obj_query(self):
+        url = 'http://127.0.0.1:8080/v2/objects'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        desired_id = 'dit:exportOpportunities:Enquiry:49863'
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(1), json.dumps({
+                'query': {
+                    'bool': {
+                        'filter': {'term': {'id': desired_id}},
+                    }
+                }
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        ids = [item['_source']['id'] for item in result['hits']['hits']]
+        self.assertEqual([desired_id], ids)
+
+    @async_test
+    async def test_v2_activities_get_filter_list_query(self):
+        url = 'http://127.0.0.1:8080/v2/objects'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        desired_id = 'dit:exportOpportunities:Enquiry:49863'
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(1), json.dumps({
+                'query': {
+                    'bool': {
+                        'filter': [{'term': {'id': desired_id}}],
+                    }
+                }
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        ids = [item['_source']['id'] for item in result['hits']['hits']]
+        self.assertEqual([desired_id], ids)
+
+    @async_test
+    async def test_v2_activities_get_aggs_query(self):
+        url = 'http://127.0.0.1:8080/v2/activities'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(2), json.dumps({
+                'aggs': {
+                    'my_agg': {
+                        'terms': {'field': 'published', 'size': 3},
+                    }
+                },
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(len(result['hits']['hits']), 2)
+        self.assertEqual(len(result['aggregations']['my_agg']['buckets']), 2)
+
+    @async_test
+    async def test_v2_activities_get_filter_aggs_query(self):
+        url = 'http://127.0.0.1:8080/v2/activities'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        path = 'tests_fixture_activity_stream_1.json'
+
+        def read_specific_file(_):
+            with open(os.path.dirname(os.path.abspath(__file__)) + '/' + path, 'rb') as file:
+                return file.read().decode('utf-8')
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_specific_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+            await fetch_all_es_data_until(has_at_least(2))
+
+        result, status, _ = await get_until_with_body(
+            url, x_forwarded_for, has_at_least(0), json.dumps({
+                'query': {
+                    'bool': {
+                        'filter': {'term': {'id': 'does-not-exist'}},
+                    }
+                },
+                'aggs': {
+                    'my_agg': {
+                        'terms': {'field': 'published', 'size': 3}
+                    }
+                },
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+        self.assertEqual(len(result['hits']['hits']), 0)
+        self.assertEqual(result['aggregations']['my_agg']['buckets'], [])
 
     @async_test
     async def test_v2_objects_get_returns_feed_data(self):

--- a/core/tests/tests_utils.py
+++ b/core/tests/tests_utils.py
@@ -166,7 +166,11 @@ async def get(url, auth, x_forwarded_for, body):
 
 
 async def get_until(url, x_forwarded_for, condition):
-    body = b'{"size": 1000, "sort": [{"published": {"order": "desc"}}]}'
+    return await get_until_with_body(url, x_forwarded_for, condition,
+                                     b'{"size": 1000, "sort": [{"published": {"order": "desc"}}]}')
+
+
+async def get_until_with_body(url, x_forwarded_for, condition, body):
     while True:
         auth = hawk_auth_header(
             'incoming-some-id-3', 'incoming-some-secret-3', url, 'GET', body, 'application/json',


### PR DESCRIPTION
The aim of this PR is to ensure all queries are `bool` queries with `filter`, ready for a permission-related filter to be added