### PR TITLE
(feat) Remove unused POST feature

### DIFF
--- a/core/app/app_incoming.py
+++ b/core/app/app_incoming.py
@@ -27,7 +27,6 @@ from .app_incoming_server import (
     INCORRECT,
     authenticate_by_ip,
     authenticator,
-    authorizer,
     convert_errors_to_json,
     handle_get_existing,
     handle_get_metrics,
@@ -36,7 +35,6 @@ from .app_incoming_server import (
     handle_get_p2_check,
     handle_get_search_v1,
     handle_get_search_v2,
-    handle_post,
     raven_reporter,
     server_logger,
 )
@@ -121,7 +119,6 @@ async def create_incoming_application(
     private_app_v1 = web.Application(middlewares=[
         authenticate_by_ip(INCORRECT, ip_whitelist),
         authenticator(context, incoming_key_pairs, NONCE_EXPIRE),
-        authorizer(),
     ])
     private_app_v1.add_routes([
         web.get(
@@ -137,7 +134,6 @@ async def create_incoming_application(
             handle_get_existing(context),
             name='scroll',
         ),
-        web.post('/', handle_post),
         web.get(
             '/',
             handle_get_new(context)
@@ -152,7 +148,6 @@ async def create_incoming_application(
     private_app_v2 = web.Application(middlewares=[
         authenticate_by_ip(INCORRECT, ip_whitelist),
         authenticator(context, incoming_key_pairs, NONCE_EXPIRE),
-        authorizer(),
     ])
     private_app_v2.add_routes([
         web.get(

--- a/core/app/app_incoming_server.py
+++ b/core/app/app_incoming_server.py
@@ -37,7 +37,6 @@ INCORRECT = 'Incorrect authentication credentials.'
 MISSING_CONTENT_TYPE = 'Content-Type header was not set. ' + \
                        'It must be set for authentication, even if as the empty string.'
 MISSING_X_FORWARDED_PROTO = 'The X-Forwarded-Proto header was not set.'
-NOT_AUTHORIZED = 'You are not authorized to perform this action.'
 UNKNOWN_ERROR = 'An unknown error occurred.'
 
 
@@ -101,17 +100,6 @@ def lookup_credentials(incoming_key_pairs, passed_access_key_id):
     } if matching_key_pairs else None
 
 
-def authorizer():
-    @web.middleware
-    async def authorize(request, handler):
-        if request.method not in request['permissions']:
-            raise web.HTTPForbidden(text=NOT_AUTHORIZED)
-
-        return await handler(request)
-
-    return authorize
-
-
 def raven_reporter(context):
     @web.middleware
     async def _raven_reporter(request, handler):
@@ -147,10 +135,6 @@ def convert_errors_to_json():
         return response
 
     return _convert_errors_to_json
-
-
-async def handle_post(_):
-    return json_response({'secret': 'to-be-hidden'}, status=200)
 
 
 def handle_get_new(context):

--- a/core/tests/tests_utils.py
+++ b/core/tests/tests_utils.py
@@ -213,6 +213,12 @@ async def post_with_headers(url, headers):
     return (await result.text(), result.status)
 
 
+async def get_with_headers(url, headers):
+    async with aiohttp.ClientSession(skip_auto_headers=['Content-Type']) as session:
+        result = await session.get(url, headers=headers, timeout=1)
+    return (await result.text(), result.status)
+
+
 def respond_http(text, status):
     async def response(_):
         return web.Response(text=text, status=status, content_type='application/json')
@@ -307,13 +313,13 @@ def mock_env():
         'FEEDS__1__TYPE': 'activity_stream',
         'INCOMING_ACCESS_KEY_PAIRS__1__KEY_ID': 'incoming-some-id-1',
         'INCOMING_ACCESS_KEY_PAIRS__1__SECRET_KEY': 'incoming-some-secret-1',
-        'INCOMING_ACCESS_KEY_PAIRS__1__PERMISSIONS__1': 'POST',
+        'INCOMING_ACCESS_KEY_PAIRS__1__PERMISSIONS__1': '__ANYTHING__',
         'INCOMING_ACCESS_KEY_PAIRS__2__KEY_ID': 'incoming-some-id-2',
         'INCOMING_ACCESS_KEY_PAIRS__2__SECRET_KEY': 'incoming-some-secret-2',
-        'INCOMING_ACCESS_KEY_PAIRS__2__PERMISSIONS__1': 'POST',
+        'INCOMING_ACCESS_KEY_PAIRS__2__PERMISSIONS__1': '__ANYTHING__',
         'INCOMING_ACCESS_KEY_PAIRS__3__KEY_ID': 'incoming-some-id-3',
         'INCOMING_ACCESS_KEY_PAIRS__3__SECRET_KEY': 'incoming-some-secret-3',
-        'INCOMING_ACCESS_KEY_PAIRS__3__PERMISSIONS__1': 'GET',
+        'INCOMING_ACCESS_KEY_PAIRS__3__PERMISSIONS__1': '__ANYTHING__',
         'INCOMING_IP_WHITELIST__1': '1.2.3.4',
         'INCOMING_IP_WHITELIST__2': '2.3.4.5',
         'SENTRY_DSN': 'http://abc:cvb@localhost:9872/123',


### PR DESCRIPTION
This was added so it can be pen-tested. However, it doesn't look like this feature will be used.

Keeping the PERMISSIONS* environment variables, as they will be used to store the upcoming granular ES permissions