### PR TITLE
(refactor) Remove duplicated v1 code

### DIFF
--- a/core/app/app_incoming.py
+++ b/core/app/app_incoming.py
@@ -33,7 +33,6 @@ from .app_incoming_server import (
     handle_get_new,
     handle_get_p1_check,
     handle_get_p2_check,
-    handle_get_search_v1,
     handle_get_search_v2,
     raven_reporter,
     server_logger,
@@ -123,7 +122,8 @@ async def create_incoming_application(
     private_app_v1.add_routes([
         web.get(
             '/objects',
-            handle_get_search_v1(context, ALIAS_OBJECTS)
+            # /objects v1 and v2 are identical
+            handle_get_search_v2(context, ALIAS_OBJECTS)
         ),
         web.get(
             '/activities',

--- a/core/app/app_incoming_server.py
+++ b/core/app/app_incoming_server.py
@@ -247,26 +247,6 @@ def handle_get_metrics(context):
     return handle
 
 
-def handle_get_search_v1(context, alias):
-    async def handle(request):
-        body = await request.read()
-
-        results = await es_request(
-            context=context,
-            method='GET',
-            path=f'/{alias}/_search',
-            query={},
-            headers={'Content-Type': request.headers['Content-Type']},
-            payload=body,
-        )
-
-        return web.Response(body=results._body, status=200, headers={
-            'Content-Type': 'application/json; charset=utf-8',
-        })
-
-    return handle
-
-
 def handle_get_search_v2(context, alias):
 
     def ensure_filter(search):


### PR DESCRIPTION
There is a very subtle difference that makes this not-quite a refactor:
v1 objects always returns a 200, but v2 objects passes through the code
from Elasticsearch.