### PR TITLE
(feat) Limit outgoing HTTP connections per host

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -127,7 +127,8 @@ async def run_outgoing_application():
     settings.ES_URI = es_uri
     metrics_registry = CollectorRegistry()
     metrics = get_metrics(metrics_registry)
-    conn = aiohttp.TCPConnector(use_dns_cache=False, resolver=AioHttpDnsResolver(metrics))
+    conn = aiohttp.TCPConnector(limit_per_host=10, use_dns_cache=False,
+                                resolver=AioHttpDnsResolver(metrics))
     session = aiohttp.ClientSession(
         connector=conn,
         headers={'Accept-Encoding': 'identity;q=1.0, *;q=0'},


### PR DESCRIPTION
As an attempt to address what seem to be flaky/timeout-hitting connections to Elasticsearch.

There is apparently no default without this setting https://docs.aiohttp.org/en/stable/client_advanced.html. At the time of
writing, there are 15 feeds configured in the Activity Stream, so this reduces max parallel connections from ~15 -> 10.