### PR TITLE
(feat) Minimum full ingest time

### DIFF
--- a/core/app/app_outgoing_utils.py
+++ b/core/app/app_outgoing_utils.py
@@ -13,14 +13,18 @@ def flatten_generator(to_flatten):
     )
 
 
-async def repeat_until_cancelled(context, exception_intervals, to_repeat, to_repeat_args=()):
-
+async def repeat_until_cancelled(context, exception_intervals, to_repeat,
+                                 to_repeat_args=(), min_duration=0):
+    loop = asyncio.get_running_loop()
     num_exceptions_in_chain = 0
 
     while True:
         try:
+            start = loop.time()
             await to_repeat(*to_repeat_args)
+            end = loop.time()
             num_exceptions_in_chain = 0
+            await asyncio.sleep(max(min_duration - (end - start), 0))
         except asyncio.CancelledError:
             break
         except BaseException:


### PR DESCRIPTION
Some of the full ingests run in seconds, and have concern about
creating/deleting indexes so frequently: ES reports memory leaks in some
versions.

Adding a minimim full ingest time so as to make the ingest roughly
homogenous with respect to time. At least, as ingests take longer, the
ingests will become more homogenous since there will be no sleep.