### PR TITLE
Add mapping for actor.dit:emailAddress

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -355,6 +355,9 @@ async def create_activities_index(context, index_name):
                         'actor.dit:companiesHouseNumber': {
                             'type': 'keyword',
                         },
+                        'actor.dit:emailAddress': {
+                            'type': 'keyword',
+                        },
                         'object.geocoordinates': {
                             'type': 'geo_point'
                         }


### PR DESCRIPTION
This change adds a mapping to be able to query activities by the email address of the actor (`actor.dit:emailAddress`). 

This will allow the [enquiry management tool](https://github.com/uktrade/enquiry-mgmt-tool) to be able to filter out duplicate emails from the forms API depending on the email address.