### PR TITLE
tests: fix flaxy delete index behaviour test

### DIFF
--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1542,7 +1542,7 @@ class TestApplication(TestBase):
 
             # The full ingest has a minimum duration, and the delete is only called at the
             # beginning of the second ingest
-            await ORIGINAL_SLEEP(1)
+            await ORIGINAL_SLEEP(5)
 
             # This is the point of the test: the exception should have been
             # captured, since this error is not expected


### PR DESCRIPTION
Since the test was first written the minimum time for an ingest was increased. Since this test asserts on behaviour at the beginning of the second ingest, the time to sleep in the test should have been increased.