### PR TITLE
feat: add integer ID for maxemail campaigns

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -357,6 +357,7 @@ class MaxemailFeed(Feed):
                 'name': campaign['name'],
                 'content': campaign['description'],
                 'dit:emailSubject': campaign['subject_line'],
+                'dit:maxemail:Campain:Id': int(email_campaign_id),
                 'published': timestamp
             }, {
                 'type': ['Organization', 'dit:maxemail:Sender'],


### PR DESCRIPTION
This is to make it easier to join between emails and their campaigns