### PR TITLE
feat: add directory sso feed type

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -35,6 +35,7 @@ from .utils import (
 def parse_feed_config(feed_config):
     by_feed_type = {
         'activity_stream': ActivityStreamFeed,
+        'directory_sso': DirectorySSOFeed,
         'zendesk': ZendeskFeed,
         'maxemail': MaxemailFeed,
         'aventri': EventFeed,
@@ -159,6 +160,7 @@ class Feed(metaclass=ABCMeta):
 
 
 class ActivityStreamFeed(Feed):
+    content_type = b''
 
     @classmethod
     def parse_config(cls, config):
@@ -186,10 +188,14 @@ class ActivityStreamFeed(Feed):
                 host=parsed_url.host,
                 port=str(parsed_url.port),
                 path=parsed_url.raw_path_qs,
-                content_type=b'',
+                content_type=self.content_type,
                 content=b'',
             )
         }
+
+
+class DirectorySSOFeed(ActivityStreamFeed):
+    content_type = b'text/plain'
 
 
 class ZendeskFeed(Feed):

--- a/core/tests/tests_fixture_directory_sso_listUsers.json
+++ b/core/tests/tests_fixture_directory_sso_listUsers.json
@@ -1,0 +1,37 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    {
+      "dit": "https://www.trade.gov.uk/ns/activitystreams/v1"
+    }
+  ],
+  "next": null,
+  "orderedItems": [
+    {
+      "dit:application": "DirectorySSO",
+      "id": "dit:DirectorySSO:User:1:Update",
+      "object": {
+        "dit:DirectorySSO:User:dateJoined": "2021-02-26T08:33:04.910293Z",
+        "dit:DirectorySSO:User:email": "1@example.com",
+        "id": "dit:DirectorySSO:User:1",
+        "type": "dit:DirectorySSO:User"
+      },
+      "published": "2021-02-26T08:33:04.910428Z",
+      "type": "Update"
+    },
+    {
+      "dit:application": "DirectorySSO",
+      "id": "dit:DirectorySSO:User:2:Update",
+      "object": {
+        "dit:DirectorySSO:User:dateJoined": "2021-02-26T08:33:04.909721Z",
+        "dit:DirectorySSO:User:email": "2@example.com",
+        "id": "dit:DirectorySSO:User:2",
+        "type": "dit:DirectorySSO:User"
+      },
+      "published": "2021-02-26T08:33:04.909856Z",
+      "type": "Update"
+    }
+  ],
+  "previous": null,
+  "type": "Collection"
+}


### PR DESCRIPTION
Directory SSO has two layers of hawk protection using some custom
headers, so needs to know how to send things above and beyond a standard
Activity Stream pipeline.