### PR TITLE
explicitly define disabling updates for feeds

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -330,7 +330,7 @@ async def ingest_updates(parent_context, feed):
             metric_timer(metrics['ingest_feed_duration_seconds'], [feed.unique_id, 'updates']):
 
         href = await get_feed_updates_url(context, feed.unique_id)
-        if href != feed.seed and not feed.disable_updates:
+        if not feed.disable_updates:
             indexes_without_alias, indexes_with_alias = await get_old_index_names(context)
 
             # We deliberately ingest into both the live and ingesting indexes

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -53,7 +53,7 @@ class Feed(metaclass=ABCMeta):
     updates_page_interval = 1
     exception_intervals = [1, 2, 4, 8, 16, 32, 64]
 
-    disable_updates = False
+    disable_updates = False  # this is to disable updates feed, if necessary
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Instead of having it as a hidden feature by returning the same href for updates, which would then skip updates, define explicit field to disable updates. And check before running updates. This is just to make it clearer and to avoid any confusion around.