### PR TITLE
fix: retry and reporting logic around DELETE of indexes

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -30,7 +30,7 @@ from .metrics import (
     metric_timer,
 )
 
-DELETE_TIMEOUTS = [1, 2, 4, 8, 16, 32] + [64] * 120
+DELETE_TIMEOUTS = [1, 2, 4, 8, 16, 32] + [64] * 20
 
 
 def get_new_index_names(feed_unique_id):
@@ -183,18 +183,11 @@ async def delete_indexes(context, index_names):
                         headers={'Content-Type': 'application/json'},
                         payload=b'',
                     )
-                except ESNon200Exception as exception:
-                    status = exception.args[1]
-                    context.logger.exception('Failed index DELETE of (%s)', [index_name])
-                    if 400 <= status < 500:
-                        failed_index_names.append(index_name)
-                        break
-                    await sleep(context, timeout)
                 except Exception:
                     context.logger.exception('Failed index DELETE of (%s)', [index_name])
-                    if i == len(DELETE_TIMEOUTS):
+                    if i == len(DELETE_TIMEOUTS) - 1:
                         failed_index_names.append(index_name)
-                        continue
+                        break
                     await sleep(context, timeout)
                 else:
                     break

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1619,7 +1619,7 @@ class TestApplication(TestBase):
             # The full ingest has a minimum duration, and the delete is only called at the
             # beginning of the second ingest
             on_delete_fail = True
-            await ORIGINAL_SLEEP(5)
+            await ORIGINAL_SLEEP(40)
 
             # This is the point of the test: the exception should have been
             # captured, since this error is not expected


### PR DESCRIPTION
Suspect it was reporting failures when actually it didn't need to