### PR TITLE
Index email addresses for Aventri Attendees 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v1.2.3
   hooks:
     - id: autopep8-wrapper

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -562,6 +562,7 @@ class EventFeed(Feed):
                     'please_specify_the_name_of_the_uk_company',
                     None
                 ),
+                'dit:emailAddress': attendee['email'],
             }
         }
 

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1863,6 +1863,7 @@ class TestApplication(TestBase):
         self.assertEqual(attendee['object']['dit:aventri:firstname'], 'Steve')
         self.assertEqual(attendee['object']['dit:aventri:lastname'], 'Gates')
         self.assertEqual(attendee['object']['dit:aventri:companyname'], 'Applesoft')
+        self.assertEqual(attendee['object']['dit:emailAddress'], 'test@test.com')
 
     @async_test
     async def test_aventri_event_with_zero_dates(self):


### PR DESCRIPTION
We would like to match Aventri attendees by email address so that we can
display them for Contacts on Data Hub.

This commit adds an Attendee's email to the indexed `dit:emailAddress`
field to make that possible.