### PR TITLE
feature:pass force_close for http connections to stop them being reused

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -125,7 +125,7 @@ async def run_outgoing_application():
     settings.ES_AWS_REGION = es_aws_region
     metrics_registry = CollectorRegistry()
     metrics = get_metrics(metrics_registry)
-    conn = aiohttp.TCPConnector(limit_per_host=10, use_dns_cache=False,
+    conn = aiohttp.TCPConnector(limit_per_host=10, use_dns_cache=False, force_close=True,
                                 resolver=AioHttpDnsResolver(metrics))
     session = aiohttp.ClientSession(
         connector=conn,


### PR DESCRIPTION
The maxemail feed seems to fail before completing a full ingest and this could be due to maxemail having a timeout / max number of times they can be used.