### PR TITLE
feature: use aiohttp conn with force_close for maxemail feed only

### DIFF
--- a/core/app/app_incoming.py
+++ b/core/app/app_incoming.py
@@ -88,7 +88,7 @@ async def run_incoming_application():
     context = Context(
         logger=logger, metrics=metrics,
         raven_client=raven_client, redis_client=redis_client, session=session,
-        es_semaphore=asyncio.Semaphore(value=500),
+        single_use_session=None, es_semaphore=asyncio.Semaphore(value=500),
     )
 
     with logged(context.logger.info, context.logger.warning, 'Creating listening web application',

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -682,7 +682,7 @@ class MaxemailFeed(Feed):
             with logged(context.logger.debug, context.logger.warning,
                         'maxemail Fetching campaign (%s) with payload (%s)', [url, payload]):
                 result = await http_make_request(
-                    context.session,
+                    context.single_use_session,
                     context.metrics,
                     'POST',
                     url,
@@ -731,7 +731,7 @@ class MaxemailFeed(Feed):
                     with logged(context.logger.info, context.logger.warning,
                                 'maxemail export key (%s) with payload (%s)', [url, payload]):
                         result = await http_make_request(
-                            context.session,
+                            context.single_use_session,
                             context.metrics,
                             'POST',
                             url,

--- a/core/app/utils.py
+++ b/core/app/utils.py
@@ -15,7 +15,8 @@ from .logger import (
 
 
 Context = collections.namedtuple(
-    'Context', ['logger', 'metrics', 'raven_client', 'redis_client', 'session', 'es_semaphore'],
+    'Context', ['logger', 'metrics', 'raven_client', 'redis_client',
+                'session', 'single_use_session', 'es_semaphore'],
 )
 
 


### PR DESCRIPTION
Changing all http requests to not reuse connections in https://github.com/uktrade/activity-stream/pull/228 seems to have fixed maxemail issues but has slowed down other feeds. This PR configures only maxemail to use a connection with force_close=True.