### PR TITLE
Mapping Aventri virtual event attendance field

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,18 +148,16 @@ To look at the data themselves, download Kibana 6.3.0 [here](https://www.elastic
 
 Ensure dependencies are installed and Elasticsearch and Redis are running
 
-    $ install -r core/requirements_test.txt
+    $ pip install -r core/requirements_test.txt
     $ ./tests_es_start.sh && ./tests_redis_start.sh
 
 To run all of the tests
 
-    ./tests.sh
-
-    python3 -m unittest
+    python3 -m unittest -v -b
 
 Running a single test takes the format:
 
-    ./tests.sh core.tests.tests.TestApplication.test_aventri
+    python3 -m unittest -v -b core.tests.tests.TestApplication.test_aventri
 
 ## Release process
 

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -562,7 +562,7 @@ class EventFeed(Feed):
                     'please_specify_the_name_of_the_uk_company',
                     None
                 ),
-                'dit:aventri:virtual_attendance_confirmed': attendee.get('virtual_event_attendance', None),
+                'dit:aventri:virtual_event_attendance': attendee['virtual_event_attendance'],
                 'dit:emailAddress': attendee['email'],
             }
         }

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -562,6 +562,7 @@ class EventFeed(Feed):
                     'please_specify_the_name_of_the_uk_company',
                     None
                 ),
+                'dit:aventri:virtual_attendance_confirmed': attendee.get('virtual_event_attendance', None),
                 'dit:emailAddress': attendee['email'],
             }
         }

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1864,7 +1864,7 @@ class TestApplication(TestBase):
         self.assertEqual(attendee['object']['dit:aventri:lastname'], 'Gates')
         self.assertEqual(attendee['object']['dit:aventri:companyname'], 'Applesoft')
         self.assertEqual(attendee['object']['dit:emailAddress'], 'test@test.com')
-        self.assertEqual(attendee['object']['dit:aventri:virtual_attendance_confirmed'], 'Yes')
+        self.assertEqual(attendee['object']['dit:aventri:virtual_event_attendance'], 'Yes')
 
     @async_test
     async def test_aventri_event_with_zero_dates(self):

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1864,6 +1864,7 @@ class TestApplication(TestBase):
         self.assertEqual(attendee['object']['dit:aventri:lastname'], 'Gates')
         self.assertEqual(attendee['object']['dit:aventri:companyname'], 'Applesoft')
         self.assertEqual(attendee['object']['dit:emailAddress'], 'test@test.com')
+        self.assertEqual(attendee['object']['dit:aventri:virtual_attendance_confirmed'], 'Yes')
 
     @async_test
     async def test_aventri_event_with_zero_dates(self):

--- a/core/tests/tests_fixture_aventri_listAttendees.json
+++ b/core/tests/tests_fixture_aventri_listAttendees.json
@@ -343,6 +343,7 @@
       "verifyemail": "test@test.com",
       "viral_transactionid": "0",
       "viralid": "0",
+      "virtual_event_attendance": "Yes",
       "website": "",
       "where_are_you_interested_in_exporting_to_within_the_next_24_months": "",
       "where_do_you_currently_export_to": "",

--- a/dummy_aventri/fixture_listAttendees.json
+++ b/dummy_aventri/fixture_listAttendees.json
@@ -343,6 +343,7 @@
       "verifyemail": "test@test.com",
       "viral_transactionid": "0",
       "viralid": "0",
+      "virtual_event_attendance": "Yes",
       "website": "",
       "where_are_you_interested_in_exporting_to_within_the_next_24_months": "",
       "where_do_you_currently_export_to": "",


### PR DESCRIPTION
We need to show the word “Attended” next to the event name in Datahub for web-based events from Aventri. 

Attendance is recorded against a "virtual_event_attendance" field on the Attendee object from Aventri. This is coming from Aventri, but not currently available in Activity Stream; we will need to make changes to Activity Stream to collect this.

This PR maps the Aventri `virtual_event_attendance` field to `dit:aventri:virtual_attendance_confirmed`.