### PR TITLE
feat: remove multiplexing for maxemail (and related changes)

### DIFF
--- a/core/app/app_outgoing.py
+++ b/core/app/app_outgoing.py
@@ -140,7 +140,7 @@ async def run_outgoing_application():
         connector=single_use_conn,
         headers={'Accept-Encoding': 'identity;q=1.0, *;q=0'},
         timeout=aiohttp.ClientTimeout(
-            total=60.0,
+            total=300,
         ),
     )
 

--- a/core/app/http.py
+++ b/core/app/http.py
@@ -22,23 +22,3 @@ async def http_make_request(session, metrics, method, url, data, headers, params
                 .labels(parsed_url.host, str(result.status)).inc(len(result._body))
 
             return result
-
-
-async def http_stream_read_lines(session, metrics, method, url, data, headers):
-    """
-    Asynchronous iteration over the response data, one line at a time
-    """
-    parsed_url = yarl.URL(url)
-    total_bytes = 0
-
-    with metric_timer(metrics['http_request_duration_seconds'], [parsed_url.host]):
-        async with session.request(method, parsed_url, data=data, headers=headers) as result:
-            # Async stream reader supports iteration over lines By default
-            async for line in result.content:
-                total_bytes += len(line)
-                yield line
-
-    metrics['http_request_completed_total'] \
-        .labels(parsed_url.host, str(result.status)).inc(1)
-    metrics['http_response_body_bytes'] \
-        .labels(parsed_url.host, str(result.status)).inc(total_bytes)

--- a/core/app/utils.py
+++ b/core/app/utils.py
@@ -31,13 +31,6 @@ def sub_dict_lower(super_dict, keys):
     }
 
 
-async def async_enumerate(aiter):
-    i = 0
-    async for item in aiter:
-        yield i, item
-        i += 1
-
-
 async def cancel_non_current_tasks():
     current_task = asyncio.Task.current_task()
     all_tasks = asyncio.Task.all_tasks()


### PR DESCRIPTION
These are to work around issues calling MaxEmail

- Response payload not completed errors in MaxEmail, which I think are caused by requests that are open for a long time, and so addressed by a) not multiplexing and b) not really streaming the CSV responses

- SSL errors on the shorter responses, which are worked around by retrying certain requests

The single use session previous addressed some issues, so now using it for all MaxEmail requests.

The time between pages is greatly reduced, since there is some de-facto throttling anyway since often a page of results needs multiple requests to MaxEmail