### PR TITLE
Enable sorting objects by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ export INCOMING_IP_WHITELIST__1=1.2.3.4
 export INCOMING_IP_WHITELIST__2=2.3.4.5
 export SENTRY_DSN=http://abc:cvb@localhost:9872/123
 export SENTRY_ENVIRONMENT=test
-export VCAP_SERVICES='{"redis":[{"credentials":{"uri":"redis://127.0.0.1:6379"}}],"elasticsearch":[{"credentials":{"uri":"http://some-id:some-secret@127.0.0.1:9200"}}]}'
+export VCAP_SERVICES='{"redis":[{"credentials":{"uri":"redis://127.0.0.1:6379"}}],"opensearch":[{"credentials":{"uri":"http://some-id:some-secret@127.0.0.1:9200"}, "plan": "123-123-123"}]}'
 ```
 
 And add to the bottom of the `deactivate ()` function in that file.

--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -264,6 +264,11 @@ async def create_activities_index(context, index_name):
                     },
                     'object.name': {
                         'type': 'text',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        }
                     },
                     'object.startTime': {
                         'type': 'date',

--- a/verification_feed/app.py
+++ b/verification_feed/app.py
@@ -95,7 +95,8 @@ def get_page(timestamp, get_next_page_href):
                         'Document',
                         'dit:activityStreamVerificationFeed:Verifier'
                     ],
-                    'url': f'https://activitystream.uktrade.io/activities/{activity_id}'
+                    'url': f'https://activitystream.uktrade.io/activities/{activity_id}',
+                    'name': f'{activity_id} Test Object Name'
                 },
                 'published': datetime.utcfromtimestamp(timestamp).isoformat(),
                 'type': 'Create'


### PR DESCRIPTION
When we query for Data Hub and Aventri Events on Activity Stream (Data Hub [Events recently-added in this PR](https://github.com/uktrade/data-hub-api/pull/4165)) we would like to be able to sort them alphabetically by the name of the Event. 

In order to do this we need the `object.name` field to be a keyword, but we don't necessarily want to lose the text type field because that will be useful for search. This commit adds a `raw` field to the `name` that is of type keyword.

A search with the opensearch DSL below should be now be possible:

```
curl -XGET localhost:9200/_search \
-H "content-type: application/json" \
-d '{
    "query": {
      "match": {
        "type": "Create"
      }
    },
    "sort": {
        "object.name.raw": {
            "order": "asc",
            "unmapped_type": "string"
            }
        }
    }'
```