### PR TITLE
Add `updated` field to mappings and Aventri events

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -276,6 +276,9 @@ async def create_activities_index(context, index_name):
                     'object.endTime': {
                         'type': 'date',
                     },
+                    'object.updated': {
+                        'type': 'date',
+                    },
                     # Not AS 2.0, but is used, and is a space-separated
                     # list of keywords
                     'object.keywords': {

--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -35,7 +35,7 @@ RETRY_TIMEOUTS = [1, 2, 4, 8, 16, 32] + [64] * 20
 
 def get_new_index_names(feed_unique_id):
     today = datetime.date.today().isoformat()
-    now = str(datetime.datetime.now().timestamp()).split('.')[0]
+    now = str(datetime.datetime.now().timestamp()).split('.', maxsplit=1)[0]
     unique = random_url_safe(8)
 
     # Storing metadata in index name allows operations to match on
@@ -193,7 +193,7 @@ async def delete_indexes(context, index_names):
                     break
 
         if failed_index_names:
-            raise Exception('Failed DELETE of indexes ({})'.format(failed_index_names))
+            raise Exception(f'Failed DELETE of indexes ({failed_index_names})')
 
     await wait_for_indexes_to_delete(context, index_names)
 

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -478,6 +478,7 @@ class EventFeed(Feed):
                 'id': 'dit:aventri:Event:' + event_id,
                 'name': event['eventname'],
                 'published': published,
+                'updated': self.format_datetime(event['event_lastmodified']),
                 # The following mappings are used to allow great.gov.uk
                 # search to filter on events.
                 'attributedTo': {
@@ -561,7 +562,7 @@ class EventFeed(Feed):
                     None
                 ),
                 'dit:aventri:virtual_event_attendance': attendee['virtual_event_attendance'],
-                'dit:emailAddress': attendee['email'],
+                'dit:emailAddress': attendee['email']
             }
         }
 


### PR DESCRIPTION
We would like to sort Aventri and Data Hub Events based on when they were last updated. 

* This PR adds `object.updated` to the mappings as a date type
* And adds the `event_lastmodified` field to map to `object.updated` for Aventri Events
* Also included some fixes for some pylint warnings - I'm not totally sure they are right so good to get some eyes on them!

The `object.updated` field is part of [the Activity Stream spec]( https://www.w3.org/TR/activitystreams-vocabulary/#dfn-updated), and as we want to sort by the same field on Data Hub Events we thought better to have a standardised name.

We are not removing the existing `dit:aventri:lastmodified` because it may be used by other API consumers (Great.gov?)

