### PR TITLE
Map Aventri Attendees' first and last names as keywords

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -310,6 +310,12 @@ async def create_activities_index(context, index_name):
                     },
                     'object.dit:public': {
                         'type': 'boolean'
+                    },
+                    'object.dit:firstName': {
+                        'type': 'keyword'
+                    },
+                    'object.dit:lastName': {
+                        'type': 'keyword'
                     }
                 },
             }),

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -562,7 +562,9 @@ class EventFeed(Feed):
                     None
                 ),
                 'dit:aventri:virtual_event_attendance': attendee['virtual_event_attendance'],
-                'dit:emailAddress': attendee['email']
+                'dit:emailAddress': attendee['email'],
+                'dit:firstName': attendee['fname'],
+                'dit:lastName': attendee['lname']
             }
         }
 


### PR DESCRIPTION
We would like to be able to sort attendees for Aventri events by
first/last names.

There are existing fields on `dit:aventri:Attendees` objects with fields
`dit:aventri:lastName` and `dit:aventri:firstName`, but as we want to
avoid mapping feed-specific fields when they could be generic, we're creating
new fields called `dit:firstName` and `dit:lastName`.
