### PR TITLE
DET-242 Bug - Fix company name mapping

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -558,7 +558,7 @@ class EventFeed(Feed):
                 'dit:aventri:firstname': attendee['fname'],
                 'dit:aventri:lastname': attendee['lname'],
                 'dit:aventri:companyname': attendee.get(
-                    'please_specify_the_name_of_the_uk_company',
+                    'company',
                     None
                 ),
                 'dit:aventri:virtual_event_attendance': attendee['virtual_event_attendance'],
@@ -566,7 +566,7 @@ class EventFeed(Feed):
                 'dit:firstName': attendee['fname'],
                 'dit:lastName': attendee['lname'],
                 'dit:companyName': attendee.get(
-                    'please_specify_the_name_of_the_uk_company',
+                    'company',
                     None
                 ),
             }

--- a/core/tests/tests_fixture_aventri_listAttendees.json
+++ b/core/tests/tests_fixture_aventri_listAttendees.json
@@ -84,7 +84,7 @@
       "checkout": "0000-00-00",
       "city": "",
       "cliqbook_full_xml": null,
-      "company": "",
+      "company": "Applesoft",
       "country": "",
       "country_211021857": "",
       "created": "2018-08-31 11:44:00",


### PR DESCRIPTION
We would like to be able to sort attendees for Aventri events by `company name`

At the moment in Kibana, the company name field is always being returned as `null` 
![image](https://user-images.githubusercontent.com/83657534/183653717-5fc74b96-02bc-4812-a31a-2cdf4ae5e7ef.png)
![image](https://user-images.githubusercontent.com/83657534/183653797-45f50eff-0503-48d4-84be-2b4874b1a8d9.png)
The correct mapping for the field is `company` not `please_specify_the_name_of_the_uk_company` so this PR changes this. 
