### PR TITLE
Add registration status as keyword

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -319,6 +319,9 @@ async def create_activities_index(context, index_name):
                     },
                     'object.dit:companyName': {
                         'type': 'keyword'
+                    },
+                    'object.dit:registrationStatus': {
+                        'type': 'keyword'
                     }
                 },
             }),

--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -569,6 +569,7 @@ class EventFeed(Feed):
                     'company',
                     None
                 ),
+                'dit:registrationStatus': attendee['registrationstatus'],
             }
         }
 


### PR DESCRIPTION
We need to prevent incomplete registrations from displaying on the front end. These will display blank fields, which look like a fault and could remain incomplete indefinitely so we want to block them. There is a specific registration status for these, “incomplete” so we should be able to identify them from that.  

To filter to remove `registration status = Incomplete` we need to add `dit:registrationStatus` as a keyword