### PR TITLE
Adding country, uk region and organiser as keyword fields

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -331,7 +331,7 @@ async def create_activities_index(context, index_name):
                     },
                     'object.dit:ukRegion.name': {
                         'type': 'keyword'
-                    }
+                    },
                     'object.dit:organiser.name': {
                         'type': 'keyword'
                     }

--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -322,6 +322,18 @@ async def create_activities_index(context, index_name):
                     },
                     'object.dit:registrationStatus': {
                         'type': 'keyword'
+                    },
+                    'object.dit:aventri:location_country': {
+                        'type': 'keyword'
+                    },
+                    'object.dit:address_country.name': {
+                        'type': 'keyword'
+                    },
+                    'object.dit:ukRegion.name': {
+                        'type': 'keyword'
+                    }
+                    'object.dit:organiser.name': {
+                        'type': 'keyword'
                     }
                 },
             }),


### PR DESCRIPTION
Adding country, uk region and organiser as keyword fields so we can filter on them in data hub. 