### PR TITLE
Add keyword fields to elastic index

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -329,10 +329,13 @@ async def create_activities_index(context, index_name):
                     'object.dit:address_country.name': {
                         'type': 'keyword'
                     },
-                    'object.dit:ukRegion.name': {
+                    'object.dit:ukRegion.id': {
                         'type': 'keyword'
                     },
-                    'object.dit:organiser.name': {
+                    'object.dit:organiser.id': {
+                        'type': 'keyword'
+                    },
+                    'object.dit:eventType.id': {
                         'type': 'keyword'
                     }
                 },


### PR DESCRIPTION
These fields have been added as keywords:

`object.dit:ukRegion.id`
`object.dit:organiser.id`
`object.dit:eventType.id`

                   