### PR TITLE
Fix Aventri event dates returning null when the time is set to midnight

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -580,7 +580,7 @@ class EventFeed(Feed):
     def format_date_and_time(aventri_date, aventri_time):
         checked_date = aventri_date if aventri_date else '0000-00-00'
         checked_time = aventri_time if aventri_time else '00:00:00'
-        if checked_date == '0000-00-00' or checked_time == '00:00:00':
+        if checked_date == '0000-00-00':
             return None
 
         return datetime.datetime.strptime(


### PR DESCRIPTION
At the moment, if the event start and/or end time is set to midnight (either by the event creator or by the logic in the code if the value is missing), the event `startTime` and `endTime` fields are returned as Null. However, we only want these fields to be Null if there is no event date.