### PR TITLE
feat: increase P2 grace period to 2 days

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -258,7 +258,7 @@ class ZendeskFeed(Feed):
 
 class EventFeed(Feed):
 
-    down_grace_period = 60 * 60 * 4
+    down_grace_period = 60 * 60 * 48
     full_ingest_page_interval = 0  # There are sleeps in tht HTTP requests in this class
     full_ingest_interval = 60 * 60
 


### PR DESCRIPTION
A follow on from 9ccb79dd9e699a925f9641505298c8f6c88a4f61, since the success status is now saved less frequently, we would have to wait longer until it not being saved is an issue - essentially the maximum amount of time we expect a full ingest to take

https://trello.com/c/Y7Vc6Qso/6-slack-notifications-when-activity-stream-fails