### PR TITLE
feat: move grace period increase to Activity Stream format feeds

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -44,7 +44,7 @@ class Feed(metaclass=ABCMeta):
     """
     Abstract base class for all feeds with default functionality defined
     """
-    down_grace_period = 60 * 2
+    down_grace_period = 60 * 60 * 48
 
     full_ingest_page_interval = 0.25
     full_ingest_interval = 120
@@ -258,7 +258,7 @@ class ZendeskFeed(Feed):
 
 class EventFeed(Feed):
 
-    down_grace_period = 60 * 60 * 48
+    down_grace_period = 60 * 60 * 4
     full_ingest_page_interval = 0  # There are sleeps in tht HTTP requests in this class
     full_ingest_interval = 60 * 60
 


### PR DESCRIPTION
The change in 6284a40b1736780531f1139628cbacd7e1a38d1a was on the wrong feed, wanted to do it on the regular/internal Activity Stream feeds, rather than Aventri. We might want to bump the Aventri grace down the line, but not reason to do that right now

https://trello.com/c/Y7Vc6Qso/6-slack-notifications-when-activity-stream-fails