### PR TITLE
refactor Aventri attendee feed in an attempt to fix new virtual fields

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -576,21 +576,15 @@ class EventFeed(Feed):
                 'dit:aventri:email': attendee['email'],
                 'dit:aventri:firstname': attendee['fname'],
                 'dit:aventri:lastname': attendee['lname'],
-                'dit:aventri:companyname': attendee.get(
-                    'company',
-                    None
+                'dit:aventri:companyname': attendee.get('company', None),
+                'dit:aventri:virtualeventattendance': attendee['virtual_event_attendance'],
+                'dit:aventri:lastlobbylogin': self.format_datetime(
+                    attendee.get('last_lobby_login', None)
                 ),
                 'dit:aventri:attendeeQuestions': {
                     question: attendee.get(question)
                     for question in event['questions']
                 } if event['questions'] is not None else None,
-                'dit:aventri:virtualEventAttendance': attendee['virtual_event_attendance'],
-                'dit:aventri:lastLobbyLogin': self.format_datetime(attendee['last_lobby_login']),
-                'dit:emailAddress': attendee['email'],
-                'dit:firstName': attendee['fname'],
-                'dit:lastName': attendee['lname'],
-                'dit:registrationStatus': attendee['registrationstatus'],
-                'dit:companyName': attendee['company']
             }
         }
 

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1877,9 +1877,8 @@ class TestApplication(TestBase):
         self.assertEqual(attendee['object']['dit:aventri:firstname'], 'Steve')
         self.assertEqual(attendee['object']['dit:aventri:lastname'], 'Gates')
         self.assertEqual(attendee['object']['dit:aventri:companyname'], 'Applesoft')
-        self.assertEqual(attendee['object']['dit:emailAddress'], 'test@test.com')
-        self.assertEqual(attendee['object']['dit:aventri:virtualEventAttendance'], 'Yes')
-        self.assertEqual(attendee['object']['dit:aventri:lastLobbyLogin'], '2018-08-23T04:37:39')
+        self.assertEqual(attendee['object']['dit:aventri:virtualeventattendance'], 'Yes')
+        self.assertEqual(attendee['object']['dit:aventri:lastlobbylogin'], '2018-08-23T04:37:39')
         self.assertEqual(
             attendee['object']['dit:aventri:attendeeQuestions'],
             {'question_1': '1', 'question_2': 'Answer', 'question_3': '2'}
@@ -1961,8 +1960,8 @@ class TestApplication(TestBase):
         self.assertEqual(attendee['object']['dit:aventri:firstname'], 'Steve')
         self.assertEqual(attendee['object']['dit:aventri:lastname'], 'Gates')
         self.assertEqual(attendee['object']['dit:aventri:companyname'], None)
-        self.assertEqual(attendee['object']['dit:emailAddress'], 'test@test.com')
-        self.assertEqual(attendee['object']['dit:aventri:virtualEventAttendance'], 'Yes')
+        self.assertEqual(attendee['object']['dit:aventri:virtualeventattendance'], 'Yes')
+        self.assertEqual(attendee['object']['dit:aventri:lastlobbylogin'], None)
         self.assertEqual(attendee['object']['dit:aventri:attendeeQuestions'], {})
 
     @async_test

--- a/core/tests/tests_fixture_aventri_listAttendees_no_company.json
+++ b/core/tests/tests_fixture_aventri_listAttendees_no_company.json
@@ -196,7 +196,7 @@
       "is_the_company_a_subsidiary_or_overseas_office_of_a_uk_company": "",
       "is_the_company_a_uk_private_or_public_limited_company": "",
       "language": "eng",
-      "last_lobby_login": "2018-08-23 04:37:39",
+      "last_lobby_login": null,
       "lastactivity": "0000-00-00 00:00:00",
       "lastmodified": "2018-08-31 11:44:00",
       "linkedinid": null,


### PR DESCRIPTION
This is an attempt to fix virtual fields for Aventri Attendee. somehow one of the field is missing and the other one field name is incorrect.

This also removes seemingly duplicate fields that are not being used anywhere.