### PR TITLE
feat: proxy requests to root to handle more recent clients

### DIFF
--- a/core/app/app_incoming.py
+++ b/core/app/app_incoming.py
@@ -28,6 +28,7 @@ from .app_incoming_server import (
     authenticate_by_ip,
     authenticator,
     convert_errors_to_json,
+    handle_root,
     handle_get_metrics,
     handle_get_p1_check,
     handle_get_p2_check,
@@ -154,6 +155,10 @@ async def create_incoming_application(
         authenticator(context, incoming_key_pairs, NONCE_EXPIRE),
     ])
     private_app_v3.add_routes([
+        web.get(
+            '/',
+            handle_root(context),
+        ),
         web.get(
             '/activities/_search',
             handle_get_search_v2(context, ALIAS_ACTIVITIES),

--- a/core/app/app_incoming_server.py
+++ b/core/app/app_incoming_server.py
@@ -215,6 +215,26 @@ def handle_get_metrics(context):
     return handle
 
 
+def handle_root(context):
+
+    async def handle(_):
+        results = await es_request(
+            context=context,
+            method='GET',
+            path='/',
+            query={},
+            headers={},
+            payload=b''
+        )
+
+        return web.Response(body=results._body, status=results.status, headers={
+            'Content-Type': 'application/json; charset=utf-8',
+            'Server': 'activity-stream'
+        })
+
+    return handle
+
+
 def handle_get_search_v2(context, alias):
 
     async def handle(request):

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -760,6 +760,26 @@ class TestApplication(TestBase):
         self.assertEqual(len(result['aggregations']['my_agg']['buckets']), 2)
 
     @async_test
+    async def test_v3_root(self):
+        url = 'http://127.0.0.1:8080/v3/'
+        x_forwarded_for = '1.2.3.4, 127.0.0.0'
+
+        with patch('asyncio.sleep', wraps=fast_sleep):
+            await self.setup_manual(env=mock_env(), mock_feed=read_file,
+                                    mock_feed_status=lambda: 200,
+                                    mock_headers=lambda: {})
+        _, status, _ = await get_until_with_body(
+            url, x_forwarded_for, lambda _: True, json.dumps({
+                'aggs': {
+                    'my_agg': {
+                        'terms': {'field': 'published', 'size': 3},
+                    }
+                },
+            }).encode('utf-8'))
+
+        self.assertEqual(status, 200)
+
+    @async_test
     async def test_v3_activities_get_aggs_query(self):
         url = 'http://127.0.0.1:8080/v3/activities/_search'
         x_forwarded_for = '1.2.3.4, 127.0.0.0'


### PR DESCRIPTION
Recent Elastic/Opensearch clients seem to make a request to the root to verify the server.

(And the "root" here is /v3/ - all requests are prefixed)