### PR TITLE
Revert "fix: bump python to 3.8"

### DIFF
--- a/core/runtime.txt
+++ b/core/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.*
+python-3.7.*


### PR DESCRIPTION
This reverts commit fd59d0837eecfe3496f29b9035c96203cc2d9e71.