### PR TITLE
feat: decrease number of shards per feed to 1 (plus replica) - again

### DIFF
--- a/core/app/app_outgoing_elasticsearch.py
+++ b/core/app/app_outgoing_elasticsearch.py
@@ -222,7 +222,7 @@ async def wait_for_indexes_to_delete(context, index_names):
 
 
 async def create_activities_index(context, index_name):
-    num_primary_shards = 3
+    num_primary_shards = 1
     num_replicas_per_shard = 1
 
     with logged(context.logger.debug, context.logger.warning, 'Creating index (%s)', [index_name]):
@@ -367,7 +367,7 @@ async def create_activities_index(context, index_name):
 
 
 async def create_objects_index(context, index_name):
-    num_primary_shards = 3
+    num_primary_shards = 1
     num_replicas_per_shard = 1
 
     with logged(context.logger.debug, context.logger.warning, 'Creating index (%s)', [index_name]):

--- a/core/tests/tests_utils.py
+++ b/core/tests/tests_utils.py
@@ -230,7 +230,7 @@ def respond_shards(request):
     is_schema = 'schema' in request.match_info['index_name']
     shard_state = \
         [{'state': 'STARTED'}] * 1 if is_schema else \
-        [{'state': 'STARTED'}] * 6
+        [{'state': 'STARTED'}] * 2
     return web.Response(text=json.dumps(shard_state), status=200, content_type='application/json')
 
 


### PR DESCRIPTION
This decreases the number of primary shards per feed to 1.

In production the largest shard is 1.1GB. According to https://opensearch.org/blog/optimize-opensearch-index-shard-size/ shards should be between 10GB and 50GB depending on load type - so I think we're safe to increase.

The reason for this isn't just to align with the guidance: we're getting a lot of 429s on searches. Each search is actually a "search on each shard" and so each shard contributes, we think, to a some limit being reached.

This was done and reverted recently. However, because there is a delay on this taking an effect, it might not have been left long enought. Trying again.