### PR TITLE
fix: force a non-empty content-type header for GET requests

### DIFF
--- a/core/app/feeds.py
+++ b/core/app/feeds.py
@@ -190,10 +190,10 @@ class ActivityStreamFeed(Feed):
                 host=parsed_url.host,
                 port=str(parsed_url.port),
                 path=parsed_url.raw_path_qs,
-                content_type=b'',
+                content_type=b'text/plain',
                 content=b'',
             ),
-            'Content-Type': '',
+            'Content-Type': 'text/plain',
         }
 
 

--- a/core/tests/tests.py
+++ b/core/tests/tests.py
@@ -1210,8 +1210,8 @@ class TestApplication(TestBase):
         self.assertEqual(self.feed_requested[0].result(
         ).headers['Authorization'], (
             'Hawk '
-            'mac="keUgjONtI1hLtS4DzGl+0G63o1nPFmvtIsTsZsB/NPM=", '
-            'hash="B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=", '
+            'mac="2bwVsvN/PASaUjQWCj9ySuyY5PswD/LNaeBcIB8ki00=", '
+            'hash="q/t+NNAkQZNlq/aAD6PlexImwQTxwgT2MahfTa9XRLA=", '
             'id="feed-some-id", '
             'ts="1326542401", '
             'nonce="c29tZX"'
@@ -1281,8 +1281,8 @@ class TestApplication(TestBase):
         self.assertEqual(self.feed_requested[0].result(
         ).headers['Authorization'], (
             'Hawk '
-            'mac="keUgjONtI1hLtS4DzGl+0G63o1nPFmvtIsTsZsB/NPM=", '
-            'hash="B0weSUXsMcb5UhL41FZbrUJCAotzSI3HawE1NPLRUz8=", '
+            'mac="2bwVsvN/PASaUjQWCj9ySuyY5PswD/LNaeBcIB8ki00=", '
+            'hash="q/t+NNAkQZNlq/aAD6PlexImwQTxwgT2MahfTa9XRLA=", '
             'id="feed-some-id", '
             'ts="1326542401", '
             'nonce="c29tZX"'


### PR DESCRIPTION
Looks like export opportunities doesn't allow the empty header, and returns a 500